### PR TITLE
Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ sudo /sbin/insmod ./datadev.ko cfgSize=0x50000 cfgRxCount=256 cfgTxCount=16
 $ sudo chmod 666 /dev/datadev*
 
 # Check for the loaded device
-$ cat /proc/data_dev0
+$ cat /proc/datadev0
 
 ```
 Note: There is a bug (we think in the PCIe IP core) that bricks the DMA when using `rmmod` to unload the driver.

--- a/software/setup_env_template.sh
+++ b/software/setup_env_template.sh
@@ -1,5 +1,6 @@
 # Setup environment
-source /afs/slac.stanford.edu/g/reseng/rogue/anaconda/rogue_pre-release.sh
+#source /afs/slac.stanford.edu/g/reseng/rogue/anaconda/rogue_pre-release.sh
+#conda activate rogue_env
 
 # Package directories
 export LOC_DIR=${PWD}/python


### PR DESCRIPTION
Should be /dev/datadev* instead of /dev/data_dev* in README