### PR TITLE
Make setupLibPaths.py more robust so can be imported from unrelated dirs

### DIFF
--- a/software/scripts/setupLibPaths.py
+++ b/software/scripts/setupLibPaths.py
@@ -11,7 +11,7 @@
 import pyrogue as pr
 import os
 
-top_level = os.getcwd().split('software')[0]
+top_level = os.path.realpath(__file__).split('software')[0]
 
 pr.addLibraryPath(top_level+'firmware/submodules/axi-pcie-core/python')
 pr.addLibraryPath(top_level+'firmware/submodules/lcls2-pgp-fw-lib/python')


### PR DESCRIPTION

Needed for embedded python import of setupLibPaths.py from C++ from other apps.