### PR TITLE
Fix VBIN value (Opal is zero based)

### DIFF
--- a/software/config/Opal1000.yml
+++ b/software/config/Opal1000.yml
@@ -21,7 +21,7 @@ ClinkRoot:
         UartOpal1000: # OPAL 1000 UART interface
           OR: '12'     # Output resolution, i.e. bits per pixel.  Set to 12. (value from Bruce Hill)
           MO: '1'      # Pulse width exposure control (value from Bruce Hill)
-          VBIN: '1'    # Vertical binning, set to 1. (value from Bruce Hill)
+          VBIN: '0'    # Vertical binning, set to 0. (value from Bruce Hill)
           VR: '1'      # Enable vertical remapping (deinterlace on camera w/ 4ms delay, value from Bruce Hill)
           CCE[0]: '0'  # Normal Polarity CC1 trigger  (value from Bruce Hill)
           CCE[1]: '0'  # Normal Polarity CC1 trigger  (value from Bruce Hill)


### PR DESCRIPTION
Sorry, was wrong on my email last March.
Opal vertical binning factor is 0 based: i.e.
0 = bin by 1
1 = bin by 2
2 = bin by 4
3 = bin by 8