### PR TITLE
add support for multiple rogue devices in one conda env

### DIFF
--- a/firmware/python/cameralink_gateway/__init__.py
+++ b/firmware/python/cameralink_gateway/__init__.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python
 
+# this sys.path.append is a hack to allow a rogue device to import its
+# own version of device-specific submodules (surf/axi-pcie-core etc.) that
+# have been placed as subdirectories here by setup.py.  ryan herbst
+# thinks of these packages as a device-specific "board support package".
+# this allows one to put multiple devices in the same conda env.
+# a cleaner approach would be to use relative imports everywhere, but
+# that would be a lot of work for the tid-air people - cpo.
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
 from cameralink_gateway._Application                  import *
 from cameralink_gateway._ClinkDevKcu1500              import *
 from cameralink_gateway._ClinkDevSlacPgpCardG4        import *

--- a/firmware/python/setup.py
+++ b/firmware/python/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+# use softlinks to make the various "board-support-package" submodules
+# look like subpackages.  Then __init__.py will modify
+# sys.path so that the correct "local" versions of surf etc. are
+# picked up.  A better approach would be using relative imports
+# in the submodules, but that's more work.  -cpo
+
+subpackages = ['surf/python/surf','axi-pcie-core/python/axipcie','lcls-timing-core/python/LclsTimingCore','lcls2-pgp-fw-lib/python/lcls2_pgp_fw_lib','clink-gateway-fw-lib/python/ClinkFeb','l2si-core/python/l2si_core']
+
+import os
+print(os.path.dirname(os.path.realpath(__file__)))
+
+for pkgpath in subpackages:
+    pkgname = pkgpath.split('/')[-1]
+    linkname = os.path.join('cameralink_gateway',pkgname)
+    if os.path.islink(linkname): os.remove(linkname)
+    os.symlink(os.path.join('../../../firmware/submodules',pkgpath),linkname)
+
+setup(
+    name = 'cameralink_gateway',
+    description = 'LCLS II cameralink package',
+    packages = find_packages(),
+)


### PR DESCRIPTION
Hi Larry,

I think this PR should be straightforward: we're just duplicating a pattern we've already implemented for the TimeTool device.  We had extensive discussions with Ryan/Ben at that time.  It allows us to put multiple rogue devices in one conda env, each with its own version of surf etc. which is critical for us.  The pattern has been working well for us.

Thanks...

chris