### PR TITLE
XPM Back Pressuring Support

### DIFF
--- a/firmware/common/rtl/AppLane.vhd
+++ b/firmware/common/rtl/AppLane.vhd
@@ -43,6 +43,7 @@ entity AppLane is
       -- Trigger Event streams (axilClk domain)
       eventTrigMsgMaster   : in  AxiStreamMasterType;
       eventTrigMsgSlave    : out AxiStreamSlaveType;
+      eventTrigMsgCtrl     : out AxiStreamCtrlType;
       eventTimingMsgMaster : in  AxiStreamMasterType;
       eventTimingMsgSlave  : out AxiStreamSlaveType;
       -- DMA Interface (dmaClk domain)
@@ -55,6 +56,18 @@ entity AppLane is
 end AppLane;
 
 architecture mapping of AppLane is
+
+   constant AXIL_CONFIG_C : AxiLiteCrossbarMasterConfigArray(1 downto 0) := genAxiLiteConfig(2, AXI_BASE_ADDR_G, 19, 16);
+
+   signal axilWriteMasters : AxiLiteWriteMasterArray(1 downto 0);
+   signal axilWriteSlaves  : AxiLiteWriteSlaveArray(1 downto 0);
+   signal axilReadMasters  : AxiLiteReadMasterArray(1 downto 0);
+   signal axilReadSlaves   : AxiLiteReadSlaveArray(1 downto 0);
+
+   signal eventTrigPauseThresh : slv(31 downto 0);
+
+   signal trigMsgMaster : AxiStreamMasterType;
+   signal trigMsgSlave  : AxiStreamSlaveType;
 
    signal sifClMaster : AxiStreamMasterType;
    signal sifClSlave  : AxiStreamSlaveType;
@@ -69,6 +82,75 @@ architecture mapping of AppLane is
    signal appObSlave  : AxiStreamSlaveType;
 
 begin
+
+   --------------------
+   -- AXI-Lite Crossbar
+   --------------------
+   U_AXIL_XBAR : entity surf.AxiLiteCrossbar
+      generic map (
+         TPD_G              => TPD_G,
+         NUM_SLAVE_SLOTS_G  => 1,
+         NUM_MASTER_SLOTS_G => 2,
+         MASTERS_CONFIG_G   => AXIL_CONFIG_C)
+      port map (
+         axiClk              => axilClk,
+         axiClkRst           => axilRst,
+         sAxiWriteMasters(0) => axilWriteMaster,
+         sAxiWriteSlaves(0)  => axilWriteSlave,
+         sAxiReadMasters(0)  => axilReadMaster,
+         sAxiReadSlaves(0)   => axilReadSlave,
+         mAxiWriteMasters    => axilWriteMasters,
+         mAxiWriteSlaves     => axilWriteSlaves,
+         mAxiReadMasters     => axilReadMasters,
+         mAxiReadSlaves      => axilReadSlaves);
+
+   -------------------
+   -- XPM Backpressure
+   -------------------
+   U_EventTrigPause : entity surf.AxiStreamFifoV2
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         INT_PIPE_STAGES_G   => 0,
+         PIPE_STAGES_G       => 0,
+         SLAVE_READY_EN_G    => true,
+         -- FIFO configurations
+         GEN_SYNC_FIFO_G     => true,
+         FIFO_ADDR_WIDTH_G   => 9,
+         FIFO_FIXED_THRESH_G => false,  -- FALSE: Using dynamic fifoPauseThresh instead
+         MEMORY_TYPE_G       => "block",
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => DMA_AXIS_CONFIG_G,
+         MASTER_AXI_CONFIG_G => DMA_AXIS_CONFIG_G)
+      port map (
+         -- Slave Port
+         sAxisClk        => axilClk,
+         sAxisRst        => axilRst,
+         sAxisMaster     => eventTrigMsgMaster,
+         sAxisSlave      => eventTrigMsgSlave,
+         sAxisCtrl       => eventTrigMsgCtrl,
+         fifoPauseThresh => eventTrigPauseThresh(8 downto 0),
+         -- Master Port
+         mAxisClk        => axilClk,
+         mAxisRst        => axilRst,
+         mAxisMaster     => trigMsgMaster,
+         mAxisSlave      => trigMsgSlave);
+
+   U_EventTrigPauseThresh : entity surf.AxiLiteRegs
+      generic map (
+         TPD_G           => TPD_G,
+         NUM_WRITE_REG_G => 1,
+         INI_WRITE_REG_G => (0 => x"0000_0000"))
+      port map (
+         -- AXI-Lite Bus
+         axiClk           => axilClk,
+         axiClkRst        => axilRst,
+         axiReadMaster    => axilReadMasters(1),
+         axiReadSlave     => axilReadSlaves(1),
+         axiWriteMaster   => axilWriteMasters(1),
+         axiWriteSlave    => axilWriteSlaves(1),
+         -- User Read/Write registers
+         writeRegister(0) => eventTrigPauseThresh);
 
    -----------------------
    -- DMA to HW ASYNC FIFO
@@ -109,9 +191,9 @@ begin
          NUM_SLAVES_G   => 3,
          MODE_G         => "ROUTED",
          TDEST_ROUTES_G => (
-            0           => "0000000-",  -- Trig on 0x0, Event on 0x1
-            1           => "00000010",  -- Map PGP[VC1] to TDEST 0x2
-            2           => "00000011"),  -- Map Timing   to TDEST 0x3
+            0           => "0000000-",        -- Trig on 0x0, Event on 0x1
+            1           => "00000010",        -- Map PGP[VC1] to TDEST 0x2
+            2           => "00000011"),       -- Map Timing   to TDEST 0x3
          TRANS_TDEST_G  => X"01",
          AXIS_CONFIG_G  => DMA_AXIS_CONFIG_G)
       port map (
@@ -119,15 +201,15 @@ begin
          axisClk         => axilClk,
          axisRst         => axilRst,
          -- AXI-Lite Interface (axisClk domain)
-         axilReadMaster  => axilReadMaster,
-         axilReadSlave   => axilReadSlave,
-         axilWriteMaster => axilWriteMaster,
-         axilWriteSlave  => axilWriteSlave,
+         axilReadMaster  => axilReadMasters(0),
+         axilReadSlave   => axilReadSlaves(0),
+         axilWriteMaster => axilWriteMasters(0),
+         axilWriteSlave  => axilWriteSlaves(0),
          -- AXIS Interfaces
-         sAxisMasters(0) => eventTrigMsgMaster,
+         sAxisMasters(0) => trigMsgMaster,
          sAxisMasters(1) => pgpObMasters(1),  -- PGP[VC1]
          sAxisMasters(2) => eventTimingMsgMaster,
-         sAxisSlaves(0)  => eventTrigMsgSlave,
+         sAxisSlaves(0)  => trigMsgSlave,
          sAxisSlaves(1)  => pgpObSlaves(1),   -- PGP[VC1]
          sAxisSlaves(2)  => eventTimingMsgSlave,
          mAxisMaster     => eventMaster,

--- a/firmware/common/rtl/AppLane.vhd
+++ b/firmware/common/rtl/AppLane.vhd
@@ -140,7 +140,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          NUM_WRITE_REG_G => 1,
-         INI_WRITE_REG_G => (0 => x"0000_0000"))
+         INI_WRITE_REG_G => (0 => x"0000_0001"))
       port map (
          -- AXI-Lite Bus
          axiClk           => axilClk,

--- a/firmware/common/rtl/Application.vhd
+++ b/firmware/common/rtl/Application.vhd
@@ -44,6 +44,7 @@ entity Application is
       -- Trigger Event streams (axilClk domain)
       eventTrigMsgMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       eventTrigMsgSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      eventTrigMsgCtrl      : out AxiStreamCtrlArray(DMA_SIZE_G-1 downto 0);
       eventTimingMsgMasters : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       eventTimingMsgSlaves  : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- DMA Interface (dmaClk domain)
@@ -125,6 +126,7 @@ begin
             -- Trigger Event streams (axilClk domain)
             eventTrigMsgMaster   => eventTrigMsgMasters(i),
             eventTrigMsgSlave    => eventTrigMsgSlaves(i),
+            eventTrigMsgCtrl     => eventTrigMsgCtrl(i),
             eventTimingMsgMaster => eventTimingMsgMasters(i),
             eventTimingMsgSlave  => eventTimingMsgSlaves(i),
             -- DMA Interface (dmaClk domain)

--- a/firmware/python/cameralink_gateway/_Application.py
+++ b/firmware/python/cameralink_gateway/_Application.py
@@ -28,10 +28,18 @@ class AppLane(pr.Device):
         #######################################
         self.add(batcher.AxiStreamBatcherEventBuilder(
             name         = 'EventBuilder',
-            offset       = 0x00000,
+            offset       = 0x0_0000,
             numberSlaves = 3, # Total number of slave indexes (not necessarily same as TDEST)
             tickUnit     = '156.25MHz',
             expand       = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'XpmPauseThresh',
+            description  = 'Threshold in unit of AXIS words (8 bytes per word).  The XPM is 48byte message. So setting this register to 0x7 would NOT back pressure until there is two message in the pipeline',
+            offset       = 0x1_0100,
+            bitSize      = 9,
+            mode         = 'RW',
         ))
 
 class Application(pr.Device):

--- a/firmware/python/cameralink_gateway/_ClinkDevRoot.py
+++ b/firmware/python/cameralink_gateway/_ClinkDevRoot.py
@@ -55,7 +55,7 @@ class ClinkDevRoot(shared.Root):
                  **kwargs):
 
         # Set the firmware Version lock = firmware/targets/shared_version.mk
-        self.FwVersionLock = 0x07100000
+        self.FwVersionLock = 0x07110000
 
         # Set local variables
         self.laneConfig     = laneConfig

--- a/firmware/targets/ClinkKcu1500Pgp2b/hdl/ClinkKcu1500Pgp2b.vhd
+++ b/firmware/targets/ClinkKcu1500Pgp2b/hdl/ClinkKcu1500Pgp2b.vhd
@@ -276,6 +276,7 @@ begin
          -- Trigger Event streams (axilClk domain)
          eventTrigMsgMasters   => eventTrigMsgMasters,
          eventTrigMsgSlaves    => eventTrigMsgSlaves,
+         eventTrigMsgCtrl      => eventTrigMsgCtrl,
          eventTimingMsgMasters => eventTimingMsgMasters,
          eventTimingMsgSlaves  => eventTimingMsgSlaves,
          -- DMA Interface (dmaClk domain)

--- a/firmware/targets/ClinkKcu1500Pgp4/hdl/ClinkKcu1500Pgp4.vhd
+++ b/firmware/targets/ClinkKcu1500Pgp4/hdl/ClinkKcu1500Pgp4.vhd
@@ -276,6 +276,7 @@ begin
          -- Trigger Event streams (axilClk domain)
          eventTrigMsgMasters   => eventTrigMsgMasters,
          eventTrigMsgSlaves    => eventTrigMsgSlaves,
+         eventTrigMsgCtrl      => eventTrigMsgCtrl,
          eventTimingMsgMasters => eventTimingMsgMasters,
          eventTimingMsgSlaves  => eventTimingMsgSlaves,
          -- DMA Interface (dmaClk domain)

--- a/firmware/targets/ClinkSlacPgpCardG4Pgp2b/hdl/ClinkSlacPgpCardG4Pgp2b.vhd
+++ b/firmware/targets/ClinkSlacPgpCardG4Pgp2b/hdl/ClinkSlacPgpCardG4Pgp2b.vhd
@@ -262,6 +262,7 @@ begin
          -- Trigger Event streams (axilClk domain)
          eventTrigMsgMasters   => eventTrigMsgMasters,
          eventTrigMsgSlaves    => eventTrigMsgSlaves,
+         eventTrigMsgCtrl      => eventTrigMsgCtrl,
          eventTimingMsgMasters => eventTimingMsgMasters,
          eventTimingMsgSlaves  => eventTimingMsgSlaves,
          -- DMA Interface (dmaClk domain)

--- a/firmware/targets/ClinkSlacPgpCardG4Pgp4/hdl/ClinkSlacPgpCardG4Pgp4.vhd
+++ b/firmware/targets/ClinkSlacPgpCardG4Pgp4/hdl/ClinkSlacPgpCardG4Pgp4.vhd
@@ -262,6 +262,7 @@ begin
          -- Trigger Event streams (axilClk domain)
          eventTrigMsgMasters   => eventTrigMsgMasters,
          eventTrigMsgSlaves    => eventTrigMsgSlaves,
+         eventTrigMsgCtrl      => eventTrigMsgCtrl,
          eventTimingMsgMasters => eventTimingMsgMasters,
          eventTimingMsgSlaves  => eventTimingMsgSlaves,
          -- DMA Interface (dmaClk domain)

--- a/firmware/targets/shared_version.mk
+++ b/firmware/targets/shared_version.mk
@@ -1,5 +1,5 @@
-# Define Firmware Version: v7.10.0.0
-export PRJ_VERSION = 0x07100000
+# Define Firmware Version: v7.11.0.0
+export PRJ_VERSION = 0x07110000
 
 # Define release
 ifndef RELEASE

--- a/software/config/defaults_LCLS-I.yml
+++ b/software/config/defaults_LCLS-I.yml
@@ -3,6 +3,7 @@ ClinkDevRoot:
     #########################################################################################################
     Application:
       AppLane[:]:
+        XpmPauseThresh: 0x1
         EventBuilder:
           Bypass: 0x4 # Masking off XPM Timing message port because not implemented in LCLS-I mode
           Timeout: 0x0

--- a/software/config/defaults_LCLS-II.yml
+++ b/software/config/defaults_LCLS-II.yml
@@ -3,6 +3,7 @@ ClinkDevRoot:
     #########################################################################################################
     Application:
       AppLane[:]:
+        XpmPauseThresh: 0x1
         EventBuilder:
           Bypass: 0x0
           Timeout: 0x0
@@ -74,7 +75,7 @@ ClinkDevRoot:
             Config_L0Select_Reset: 0x0
             Config_L0Select_Enabled: True
             AxilRdEn: True
-            Config_L0Select_RateSel: '100 Hz'
+            Config_L0Select_RateSel: '10 Hz'
             Config_L0Select_DestSel: 0x8000
             Pipeline_Depth_Clks: 20000
             Pipeline_Depth_Fids: 100


### PR DESCRIPTION
### Description
- Added a FIFO between XPM and Event build for eventTrigMsg
  - 512 samples deep
- Connected the eventTrigMsgCtrl to this FIFO
- Added a XpmPauseThresh register
- This new register is in units of 8 bytes (DMA AXIS config width).
- EventTrigMsg is 48 bytes.
- The new FIFO can buffer up to 85 EventTrigMsg frames ( = 512 deep FIFO / 48 byte msg / 8 byte per FIFO word)