### PR TITLE
Add AxiStreamDmaV2FIFO python found in lcls2-pgp-pcie-apps

### DIFF
--- a/firmware/python/cameralink_gateway/_ClinkDevRoot.py
+++ b/firmware/python/cameralink_gateway/_ClinkDevRoot.py
@@ -50,6 +50,7 @@ class ClinkDevRoot(shared.Root):
                  enableDump     = False,
                  enableConfig   = True,
                  pcieBoardType  = None,
+                 useDdr         = False,
                  enVcMask       = 0xD, # Enable lane mask: Don't connect data stream (VC1) by default because intended for C++ process
                  zmqSrvEn       = True,  # Flag to include the ZMQ server
                  **kwargs):
@@ -111,6 +112,7 @@ class ClinkDevRoot(shared.Root):
             enLclsI    = enLclsI,
             enLclsII   = enLclsII,
             boardType  = pcieBoardType,
+            useDdr     = useDdr,
             expand     = True,
         ))
 

--- a/firmware/python/cameralink_gateway/_ClinkPcieFpga.py
+++ b/firmware/python/cameralink_gateway/_ClinkPcieFpga.py
@@ -12,6 +12,7 @@ import pyrogue as pr
 
 import axipcie                 as pcie
 import lcls2_pgp_fw_lib.shared as shared
+import surf.axi                as axi
 
 class ClinkPcieFpga(pr.Device):
     def __init__(self,
@@ -20,6 +21,7 @@ class ClinkPcieFpga(pr.Device):
                  enLclsI    = True,
                  enLclsII   = False,
                  boardType  = None,
+                 useDdr     = False,
                  **kwargs):
         super().__init__(**kwargs)
 
@@ -30,6 +32,14 @@ class ClinkPcieFpga(pr.Device):
             boardType   = boardType,
             expand      = False,
         ))
+
+        if useDdr:
+            for i in range(4):
+                self.add(axi.AxiStreamDmaV2Fifo(
+                    name    = f'DmaBuffer[{i}]',
+                    offset  = 0x0010_0000+i*0x100,
+                    expand  = False,
+                ))
 
         # Application layer
         self.add(shared.ApplicationLaneConfigDict(

--- a/software/scripts/devGui.py
+++ b/software/scripts/devGui.py
@@ -175,6 +175,12 @@ if __name__ == "__main__":
         help     = "Sets the GUI type (PyDM or None)",
     )
 
+    parser.add_argument(
+        "--ddr",
+        action   = 'store_true',
+        help     = "Includes on-board DDR support",
+    )
+
     # Get the arguments
     args = parser.parse_args()
 
@@ -219,6 +225,7 @@ if __name__ == "__main__":
             pgp4           = args.pgp4,
             seuDumpDir     = args.seuDumpDir,
             pcieBoardType  = args.pcieBoardType,
+            useDdr         = args.ddr,
             enVcMask       = args.enVcMask,
         ) as root:
 


### PR DESCRIPTION
Add the AxiStreamDmaV2FIFO used for the onboard DDR to the devGui display.  It's a copy of what's found in lcls2-pgp-pcie-apps.