### PR TITLE
Repo hygiene: pin/upgrade Actions to SHAs, 2026 copyright

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.12
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-Copyright (c) 2025, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2026, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 


### PR DESCRIPTION
## Repo hygiene

- Upgrade third-party GitHub Actions to latest release, pinned to commit SHA (tag in trailing comment)
- Update `LICENSE.txt` copyright year to 2026

First-party `slaclab/ruckus` reusable workflows remain on `@main`.

### Verification
- [x] CI passes with upgraded, SHA-pinned actions
- [x] `LICENSE.txt` present with `Copyright (c) 2026`
